### PR TITLE
Add optional y axis limits to parameters

### DIFF
--- a/capabilities.json
+++ b/capabilities.json
@@ -25,6 +25,16 @@
             "displayName": "Optional: Multiplier",
             "name": "chart_multiplier",
             "kind": "Measure"
+        },
+        {
+            "displayName": "Optional: Y-Axis Upper Limit",
+            "name": "y_axis_upper_limit",
+            "kind": "Measure"
+        },
+        {
+            "displayName": "Optional: Y-Axis Lower Limit",
+            "name": "y_axis_lower_limit",
+            "kind": "Measure"
         }
     ],
     "objects": {
@@ -294,6 +304,16 @@
                         {
                             "for": {
                                 "in": "chart_multiplier"
+                            }
+                        },
+                        {
+                            "for": {
+                                "in": "y_axis_upper_limit"
+                            }
+                        },
+                        {
+                            "for": {
+                                "in": "y_axis_lower_limit"
                             }
                         }
                     ]

--- a/pbiviz.json
+++ b/pbiviz.json
@@ -4,7 +4,7 @@
         "displayName":"Funnel Plots",
         "guid":"PBIFUN",
         "visualClassName":"Visual",
-        "version":"1.1.2.9999",
+        "version":"1.1.3",
         "description":"A PowerBI custom visual for funnel plots",
         "supportUrl":"https://github.com/AUS-DOH-Safety-and-Quality/PowerBI-Funnels",
         "gitHubUrl":"https://github.com/AUS-DOH-Safety-and-Quality/PowerBI-Funnels"

--- a/src/Classes/axisLimits.ts
+++ b/src/Classes/axisLimits.ts
@@ -37,8 +37,8 @@ class axisLimits {
     };
 
     this.y = {
-      lower: yLowerInput ? yLowerInput : (yLowerInputData? yLowerInputData * multiplier : 0),
-      upper: yUpperInput ? yUpperInput : (yUpperInputData? yUpperInputData : maxRatio) * multiplier,
+      lower: yLowerInput ? yLowerInput : (yLowerInputData? yLowerInputData : 0),
+      upper: yUpperInput ? yUpperInput : (yUpperInputData? yUpperInputData : maxRatio * multiplier),
       padding: args.inputSettings.axispad.y.padding.value
     };
   }

--- a/src/Classes/axisLimits.ts
+++ b/src/Classes/axisLimits.ts
@@ -27,6 +27,9 @@ class axisLimits {
     let yUpperInput: number = args.inputSettings.axis.ylimit_u.value;
     let multiplier: number = args.inputData.multiplier;
 
+    let yLowerInputData: number = args.inputData.ylimit_l;
+    let yUpperInputData: number = args.inputData.ylimit_u;
+    
     this.x = {
       lower: xLowerInput ? xLowerInput : 0,
       upper: xUpperInput ? xUpperInput : d3.max(args.inputData.denominator) * 1.1,
@@ -34,8 +37,8 @@ class axisLimits {
     };
 
     this.y = {
-      lower: yLowerInput ? yLowerInput : args.inputData.transform(0),
-      upper: yUpperInput ? yUpperInput : args.inputData.transform(maxRatio * multiplier),
+      lower: yLowerInput ? yLowerInput : (yLowerInputData? yLowerInputData * multiplier : 0),
+      upper: yUpperInput ? yUpperInput : (yUpperInputData? yUpperInputData : maxRatio) * multiplier,
       padding: args.inputSettings.axispad.y.padding.value
     };
   }

--- a/src/Classes/dataArray.ts
+++ b/src/Classes/dataArray.ts
@@ -14,7 +14,9 @@ type dataArrayConstructorT = {
   categories?: powerbi.DataViewCategoryColumn,
   transform_text?: string,
   dot_colour?: string[],
-  odAdjust?: string
+  odAdjust?: string,
+  ylimit_u?: number,
+  ylimit_l?: number
 };
 
 class dataArray {
@@ -33,6 +35,8 @@ class dataArray {
   maxRatio: number;
   prop_labels: boolean;
   odAdjust: string;
+  ylimit_u: number;
+  ylimit_l: number
 
   constructor(pars: dataArrayConstructorT) {
     this.id = pars.id ? pars.id : null;
@@ -54,7 +58,9 @@ class dataArray {
           this.transform_text === "none"
       : null;
     this.multiplier = this.prop_labels ? 100 : this.multiplier;
-    this.odAdjust = pars.odAdjust ? pars.odAdjust : null
+    this.odAdjust = pars.odAdjust ? pars.odAdjust : null;
+    this.ylimit_u = pars.ylimit_u ? pars.ylimit_u : null;
+    this.ylimit_l = pars.ylimit_l ? pars.ylimit_l : null
   }
 }
 

--- a/src/Data Preparation/extractInputData.ts
+++ b/src/Data Preparation/extractInputData.ts
@@ -11,10 +11,15 @@ function extractInputData(inputView: powerbi.DataViewCategorical,
 
   let data_type_raw: powerbi.DataViewValueColumn = inputView.values.filter(d => d.source.roles.chart_type)[0];
   let multiplier_raw: powerbi.DataViewValueColumn = inputView.values.filter(d => d.source.roles.chart_multiplier)[0];
+  
+  let y_axis_upper_limit_raw: powerbi.DataViewValueColumn = inputView.values.filter(d => d.source.roles.y_axis_upper_limit)[0];
+  let y_axis_lower_limit_raw: powerbi.DataViewValueColumn = inputView.values.filter(d => d.source.roles.y_axis_lower_limit)[0];
 
   let numerator: number[] = <number[]>numerator_raw.values;
   let data_type: string = data_type_raw ? <string>data_type_raw.values[0] : inputSettings.funnel.data_type.value;
   let multiplier: number = multiplier_raw ? <number>multiplier_raw.values[0] : inputSettings.funnel.multiplier.value;
+  let ylimit_u: number = y_axis_upper_limit_raw ? <number>y_axis_upper_limit_raw.values[0] : inputSettings.axis.ylimit_u.value;
+  let ylimit_l: number = y_axis_lower_limit_raw ? <number>y_axis_lower_limit_raw.values[0] : inputSettings.axis.ylimit_l.value;
   let valid_ids: number[] = new Array<number>();
 
   for (let i: number = 0; i < denominator.length; i++) {
@@ -30,6 +35,8 @@ function extractInputData(inputView: powerbi.DataViewCategorical,
     highlights: numerator_raw.highlights,
     data_type: data_type,
     multiplier: multiplier,
+    ylimit_u: ylimit_u,
+    ylimit_l: ylimit_l,
     categories: inputView.categories[0],
     transform_text: inputSettings.funnel.transformation.value,
     dot_colour: [inputSettings.scatter.colour.value],

--- a/src/visual.ts
+++ b/src/visual.ts
@@ -405,11 +405,15 @@ export class Visual implements IVisual {
                           .append("path")
                           .merge(<any>this.svgSelections.lineSelection);
     lineMerged.classed('line', true);
+
+    let yLowerLimit = this.plotProperties.axisLimits.y.lower;
+    let yUpperLimit = this.plotProperties.axisLimits.y.upper;
+
     lineMerged.attr("d", d => {
       return d3.line<lineData>()
                 .x(d => this.plotProperties.xScale(d.x))
                 .y(d => this.plotProperties.yScale(d.line_value))
-                .defined(function(d) { return d.line_value !== null; })
+                .defined(function(d) { return d.line_value !== null && d.line_value > yLowerLimit && d.line_value < yUpperLimit; })
                 (d.values)
     })
     lineMerged.attr("fill", "none")


### PR DESCRIPTION
Currently y-axis limits can only be set through "Format Visual" -> "Axis Settings". This pull request adds a new data role to the visual, allowing the limits to be set via a column.